### PR TITLE
Add sentence about lein-test-refresh in Leiningen section mentioning new clojure.test compatibility

### DIFF
--- a/installing.html
+++ b/installing.html
@@ -103,7 +103,7 @@ following dependency to your <code>project.clj</code> or <code>build.boot</code>
 
 <p>Alternatively, as of version 2.2.0-alpha1, you can use <code>lein test</code>
   and write your tests using the <a href="/clojure-test.html">clojure.test
-  compatibility style</a> of expectations.</p>
+  compatibility style</a> of expectations. When using this style you can use <a href="https://github.com/jakemcc/lein-test-refresh">lein-test-refresh</a> to automatically run expectations when your Clojure source changes.</p>
 
 <h2>
 <a name="getting-started-with-boot" class="anchor" href="#getting-started-with-boot"><span class="octicon octicon-link"></span></a>Getting Started With Boot</h2>


### PR DESCRIPTION
Adds a link to lein-test-refresh in the Installing documentation that talks about using Leiningen. Plugin will need to be used instead of `lein-autoexpect` with the new clojure.test compatible syntax.